### PR TITLE
Improve guest repeater routing priority

### DIFF
--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -223,6 +223,7 @@ async def _explore(
                     contact,
                     graph=graph,
                     self_pubkey=self_pubkey,
+                    console=console,
                 )
                 node.last_visited = datetime.now(UTC).isoformat()
                 node.visit_failed = False
@@ -363,6 +364,7 @@ async def _login_fetch_logout(
     password: str = "",
     graph: MeshGraph | None = None,
     self_pubkey: str = "",
+    console: Console | None = None,
 ) -> list[dict[str, Any]]:
     """Login to a contact, fetch its neighbours, then logout.
 
@@ -374,39 +376,71 @@ async def _login_fetch_logout(
     Raises:
         RuntimeError: if login fails or no neighbour response is received.
     """
-    from rich.console import Console
-
-    console = Console()
+    if console is None:
+        console = Console()
     name = contact.get("adv_name", "?")
     target_pk = contact.get("public_key", "")
     _fetch_attempts = 3
     logged_in = False
+    strategy_used = None
 
     # ── Strategy 1: Graph-computed route ─────────────────────────────────────
     if graph is not None and self_pubkey:
         route = graph.find_route(self_pubkey, target_pk)
         if route is not None:
             path_hex = graph.route_to_path_hex(route)
-            console.print(
-                f"  [dim]Trying graph route via {len(route)} hop(s) "
-                f"(path={path_hex or 'direct'})…[/dim]"
-            )
+            hop_names = []
+            for pk in route:
+                node = graph.nodes.get(pk)
+                hop_names.append(node.name or pk[:8] if node else pk[:8])
+            if hop_names:
+                via = " → ".join(hop_names)
+                console.print(
+                    f"  [blue]Route[/blue] graph path via {len(route)} hop(s): {via} "
+                    f"[dim](path={path_hex})[/dim]"
+                )
+            else:
+                console.print("  [blue]Route[/blue] graph path: direct")
             await mesh.commands.change_contact_path(contact, path_hex)
             logged_in = await _try_login(mesh, contact, password, attempts=3)
+            if logged_in:
+                strategy_used = "graph"
+            else:
+                console.print("  [yellow]Route[/yellow] graph path failed")
+        else:
+            console.print("  [dim]Route: no graph path available[/dim]")
 
     # ── Strategy 2: Existing device route ────────────────────────────────────
     if not logged_in:
-        console.print("  [dim]Trying existing route…[/dim]")
+        out_path = contact.get("out_path", "")
+        out_path_len = contact.get("out_path_len", 0)
+        if out_path and out_path_len and out_path_len > 0:
+            console.print(
+                f"  [blue]Route[/blue] device path "
+                f"[dim](path={out_path[: out_path_len * 2]}, {out_path_len} hop(s))[/dim]"
+            )
+        else:
+            console.print("  [blue]Route[/blue] device path [dim](direct)[/dim]")
         logged_in = await _try_login(mesh, contact, password, attempts=2)
+        if logged_in:
+            strategy_used = "device"
+        else:
+            console.print("  [yellow]Route[/yellow] device path failed")
 
     # ── Strategy 3: Flood routing ────────────────────────────────────────────
     if not logged_in:
-        console.print("  [dim]Trying flood…[/dim]")
+        console.print("  [blue]Route[/blue] flood routing")
         await mesh.commands.reset_path(contact)
         logged_in = await _try_login(mesh, contact, password, attempts=2)
+        if logged_in:
+            strategy_used = "flood"
+        else:
+            console.print("  [yellow]Route[/yellow] flood failed")
 
     if not logged_in:
         raise RuntimeError(f"Could not log in to {name!r} after all routing strategies")
+
+    console.print(f"  [green]Route[/green] connected via [bold]{strategy_used}[/bold]")
 
     # ── Fetch phase ──────────────────────────────────────────────────────────
     result = None

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -403,6 +403,11 @@ async def _login_fetch_logout(
     route_desc = ""
     tried_path_hex: str | None = None  # track which path we already tried
 
+    def _set_route_vis(node_ids: list[str]) -> None:
+        """Update the graph's route visualization (visible in the web UI)."""
+        if graph is not None:
+            graph.currently_trying_route = node_ids
+
     # ── Strategy 1: Graph-computed route ─────────────────────────────────────
     if graph is not None and self_pubkey:
         route = graph.find_route(self_pubkey, target_pk)
@@ -420,10 +425,12 @@ async def _login_fetch_logout(
             else:
                 route_desc = "computed direct path"
                 console.print(f"  [blue]Trying[/blue] {route_desc}")
+            _set_route_vis([self_pubkey, *route, target_pk])
             await mesh.commands.change_contact_path(contact, path_hex)
             logged_in = await _try_login(mesh, contact, password, attempts=3)
             if not logged_in:
                 console.print(f"  [yellow]Failed[/yellow] {route_desc}")
+                _set_route_vis([])
         else:
             console.print("  [dim]No computed path available[/dim]")
 
@@ -446,19 +453,25 @@ async def _login_fetch_logout(
                 )
             else:
                 route_desc = "cached device route [dim](direct)[/dim]"
+            # For device route we only know source + target (no intermediate PKs)
+            _set_route_vis([self_pubkey, target_pk] if self_pubkey else [])
             console.print(f"  [blue]Trying[/blue] {route_desc}")
             logged_in = await _try_login(mesh, contact, password, attempts=2)
             if not logged_in:
                 console.print("  [yellow]Failed[/yellow] cached device route")
+                _set_route_vis([])
 
     # ── Strategy 3: Flood routing ────────────────────────────────────────────
     if not logged_in:
         route_desc = "flood routing"
         console.print(f"  [blue]Trying[/blue] {route_desc}")
+        _set_route_vis([])  # flood has no specific path to show
         await mesh.commands.reset_path(contact)
         logged_in = await _try_login(mesh, contact, password, attempts=2)
         if not logged_in:
             console.print(f"  [yellow]Failed[/yellow] {route_desc}")
+
+    _set_route_vis([])  # clear after all strategies
 
     if not logged_in:
         raise RuntimeError(f"Could not log in to {name!r} after all routing strategies")

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -219,7 +219,10 @@ async def _explore(
             graph.currently_visiting = node.public_key
             try:
                 neighbours = await _login_fetch_logout(
-                    mesh, contact, graph=graph, self_pubkey=self_pubkey,
+                    mesh,
+                    contact,
+                    graph=graph,
+                    self_pubkey=self_pubkey,
                 )
                 node.last_visited = datetime.now(UTC).isoformat()
                 node.visit_failed = False
@@ -364,8 +367,8 @@ async def _login_fetch_logout(
     """Login to a contact, fetch its neighbours, then logout.
 
     Uses a retry cascade with progressively broader routing strategies:
-      1. Existing device route (up to 3 login attempts)
-      2. Graph-computed route via change_contact_path (up to 2 attempts)
+      1. Graph-computed route via change_contact_path (up to 3 attempts)
+      2. Existing device route (up to 2 attempts)
       3. Flood routing via reset_path (up to 2 attempts)
 
     Raises:
@@ -377,13 +380,10 @@ async def _login_fetch_logout(
     name = contact.get("adv_name", "?")
     target_pk = contact.get("public_key", "")
     _fetch_attempts = 3
+    logged_in = False
 
-    # ── Strategy 1: Existing device route ────────────────────────────────────
-    console.print("  [dim]Trying existing route…[/dim]")
-    logged_in = await _try_login(mesh, contact, password, attempts=3)
-
-    # ── Strategy 2: Graph-computed route ─────────────────────────────────────
-    if not logged_in and graph is not None and self_pubkey:
+    # ── Strategy 1: Graph-computed route ─────────────────────────────────────
+    if graph is not None and self_pubkey:
         route = graph.find_route(self_pubkey, target_pk)
         if route is not None:
             path_hex = graph.route_to_path_hex(route)
@@ -392,7 +392,12 @@ async def _login_fetch_logout(
                 f"(path={path_hex or 'direct'})…[/dim]"
             )
             await mesh.commands.change_contact_path(contact, path_hex)
-            logged_in = await _try_login(mesh, contact, password, attempts=2)
+            logged_in = await _try_login(mesh, contact, password, attempts=3)
+
+    # ── Strategy 2: Existing device route ────────────────────────────────────
+    if not logged_in:
+        console.print("  [dim]Trying existing route…[/dim]")
+        logged_in = await _try_login(mesh, contact, password, attempts=2)
 
     # ── Strategy 3: Flood routing ────────────────────────────────────────────
     if not logged_in:

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -401,12 +401,14 @@ async def _login_fetch_logout(
     _fetch_attempts = 3
     logged_in = False
     route_desc = ""
+    tried_path_hex: str | None = None  # track which path we already tried
 
     # ── Strategy 1: Graph-computed route ─────────────────────────────────────
     if graph is not None and self_pubkey:
         route = graph.find_route(self_pubkey, target_pk)
         if route is not None:
             path_hex = graph.route_to_path_hex(route)
+            tried_path_hex = path_hex
             hop_names = []
             for pk in route:
                 node = graph.nodes.get(pk)
@@ -430,13 +432,24 @@ async def _login_fetch_logout(
         out_path = contact.get("out_path", "")
         out_path_len = contact.get("out_path_len", 0)
         if out_path and out_path_len and out_path_len > 0:
-            route_desc = f"cached device route [dim](path={out_path[: out_path_len * 2]}, {out_path_len} hop(s))[/dim]"
+            device_path_hex = out_path[: out_path_len * 2]
         else:
-            route_desc = "cached device route [dim](direct)[/dim]"
-        console.print(f"  [blue]Trying[/blue] {route_desc}")
-        logged_in = await _try_login(mesh, contact, password, attempts=2)
-        if not logged_in:
-            console.print("  [yellow]Failed[/yellow] cached device route")
+            device_path_hex = ""
+
+        if tried_path_hex is not None and device_path_hex == tried_path_hex:
+            console.print("  [dim]Skipping cached device route (same as computed path)[/dim]")
+        else:
+            if device_path_hex:
+                route_desc = (
+                    f"cached device route "
+                    f"[dim](path={device_path_hex}, {out_path_len} hop(s))[/dim]"
+                )
+            else:
+                route_desc = "cached device route [dim](direct)[/dim]"
+            console.print(f"  [blue]Trying[/blue] {route_desc}")
+            logged_in = await _try_login(mesh, contact, password, attempts=2)
+            if not logged_in:
+                console.print("  [yellow]Failed[/yellow] cached device route")
 
     # ── Strategy 3: Flood routing ────────────────────────────────────────────
     if not logged_in:

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -403,6 +403,14 @@ async def _login_fetch_logout(
     route_desc = ""
     tried_path_hex: str | None = None  # track which path we already tried
 
+    # Snapshot the device's cached route *before* we overwrite it
+    orig_out_path = contact.get("out_path", "")
+    orig_out_path_len = contact.get("out_path_len", 0)
+    if orig_out_path and orig_out_path_len and orig_out_path_len > 0:
+        orig_device_path_hex = orig_out_path[: orig_out_path_len * 2]
+    else:
+        orig_device_path_hex = ""
+
     def _set_route_vis(node_ids: list[str]) -> None:
         """Update the graph's route visualization (visible in the web UI)."""
         if graph is not None:
@@ -434,31 +442,27 @@ async def _login_fetch_logout(
         else:
             console.print("  [dim]No computed path available[/dim]")
 
-    # ── Strategy 2: Existing device route ────────────────────────────────────
+    # ── Strategy 2: Original device route ────────────────────────────────────
     if not logged_in:
-        out_path = contact.get("out_path", "")
-        out_path_len = contact.get("out_path_len", 0)
-        if out_path and out_path_len and out_path_len > 0:
-            device_path_hex = out_path[: out_path_len * 2]
+        if tried_path_hex is not None and orig_device_path_hex == tried_path_hex:
+            console.print("  [dim]Skipping original device route (same as computed path)[/dim]")
         else:
-            device_path_hex = ""
-
-        if tried_path_hex is not None and device_path_hex == tried_path_hex:
-            console.print("  [dim]Skipping cached device route (same as computed path)[/dim]")
-        else:
-            if device_path_hex:
+            if orig_device_path_hex:
                 route_desc = (
-                    f"cached device route "
-                    f"[dim](path={device_path_hex}, {out_path_len} hop(s))[/dim]"
+                    f"original device route "
+                    f"[dim](path={orig_device_path_hex}, {orig_out_path_len} hop(s))[/dim]"
                 )
+                # Restore the original device path before trying it
+                await mesh.commands.change_contact_path(contact, orig_device_path_hex)
             else:
-                route_desc = "cached device route [dim](direct)[/dim]"
+                route_desc = "original device route [dim](direct)[/dim]"
+                await mesh.commands.reset_path(contact)
             # For device route we only know source + target (no intermediate PKs)
             _set_route_vis([self_pubkey, target_pk] if self_pubkey else [])
             console.print(f"  [blue]Trying[/blue] {route_desc}")
             logged_in = await _try_login(mesh, contact, password, attempts=2)
             if not logged_in:
-                console.print("  [yellow]Failed[/yellow] cached device route")
+                console.print("  [yellow]Failed[/yellow] original device route")
                 _set_route_vis([])
 
     # ── Strategy 3: Flood routing ────────────────────────────────────────────

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -166,6 +166,7 @@ async def _explore(
         await mesh.ensure_contacts()
 
         # ── Discover 0-hop repeaters ─────────────────────────────────────────
+        graph.status_message = f"Discovering 0-hop repeaters ({wait_time:.0f}s)…"
         console.print(f"[dim]Discovering 0-hop repeaters ({wait_time:.0f}s)…[/dim]")
         scanner = MeshScanner(serial_port, baudrate=baudrate, debug=debug)
         scanner.mesh = mesh  # reuse existing connection
@@ -206,6 +207,7 @@ async def _explore(
         while True:
             pending = graph.next_repeaters_to_visit(refresh=refresh, retry=retry)
             if not pending:
+                graph.status_message = "Exploration complete"
                 console.print("[green]Exploration complete — no more nodes to visit.[/green]")
                 break
 
@@ -220,9 +222,10 @@ async def _explore(
                 console.print(f"[dim]Skipping {label} — depth {node.depth} ≥ {max_depth}[/dim]")
                 continue
 
+            remaining = graph.stats["pending"]
+            graph.status_message = f"Visiting {label} (depth {node.depth}, {remaining} remaining)"
             console.print(
-                f"Visiting [cyan]{label}[/cyan] "
-                f"(depth {node.depth}, {graph.stats['pending']} remaining)…"
+                f"Visiting [cyan]{label}[/cyan] (depth {node.depth}, {remaining} remaining)…"
             )
 
             # Find the contact in the local contact list
@@ -291,9 +294,11 @@ async def _explore(
                 graph.save(output_path)
             finally:
                 graph.currently_visiting = None
+                graph.currently_trying_route = []
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted — saving graph…[/yellow]")
+        graph.status_message = "Interrupted"
         graph.save(output_path)
     finally:
         if sniffer is not None:
@@ -416,6 +421,11 @@ async def _login_fetch_logout(
         if graph is not None:
             graph.currently_trying_route = node_ids
 
+    def _set_status(msg: str) -> None:
+        """Update the graph's status message (visible in the web UI)."""
+        if graph is not None:
+            graph.status_message = msg
+
     # ── Strategy 1: Graph-computed route (bidir first, then any) ────────────
     if graph is not None and self_pubkey:
         tried_paths: list[str] = []
@@ -443,6 +453,7 @@ async def _login_fetch_logout(
             else:
                 route_desc = f"{label} direct path"
                 console.print(f"  [blue]Trying[/blue] {route_desc}")
+            _set_status(f"Connecting to {name}: {route_desc}")
             _set_route_vis([self_pubkey, *route, target_pk])
             await mesh.commands.change_contact_path(contact, path_hex)
             logged_in = await _try_login(mesh, contact, password, attempts=3)
@@ -466,6 +477,7 @@ async def _login_fetch_logout(
                 route_desc = "original device route [dim](direct)[/dim]"
                 await mesh.commands.reset_path(contact)
             # For device route we only know source + target (no intermediate PKs)
+            _set_status(f"Connecting to {name}: cached device route")
             _set_route_vis([self_pubkey, target_pk] if self_pubkey else [])
             console.print(f"  [blue]Trying[/blue] {route_desc}")
             logged_in = await _try_login(mesh, contact, password, attempts=2)
@@ -477,18 +489,21 @@ async def _login_fetch_logout(
     if not logged_in:
         route_desc = "flood routing"
         console.print(f"  [blue]Trying[/blue] {route_desc}")
+        _set_status(f"Connecting to {name}: flood routing")
         _set_route_vis([])  # flood has no specific path to show
         await mesh.commands.reset_path(contact)
         logged_in = await _try_login(mesh, contact, password, attempts=2)
         if not logged_in:
             console.print(f"  [yellow]Failed[/yellow] {route_desc}")
 
-    _set_route_vis([])  # clear after all strategies
-
     if not logged_in:
+        _set_status(f"Failed to connect to {name}")
+        _set_route_vis([])
         raise RuntimeError(f"Could not log in to {name!r} after all routing strategies")
 
     # ── Fetch phase ──────────────────────────────────────────────────────────
+    _set_status(f"Fetching neighbours from {name}…")
+    _set_route_vis([])
     result = None
     try:
         for attempt in range(1, _fetch_attempts + 1):
@@ -499,6 +514,8 @@ async def _login_fetch_logout(
                 await asyncio.sleep(2)
     finally:
         await mesh.commands.send_logout(contact)
+
+    _set_status("")
 
     if result is None:
         raise RuntimeError(f"No neighbour response from {name!r}")

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -382,7 +382,7 @@ async def _login_fetch_logout(
     target_pk = contact.get("public_key", "")
     _fetch_attempts = 3
     logged_in = False
-    strategy_used = None
+    route_desc = ""
 
     # ── Strategy 1: Graph-computed route ─────────────────────────────────────
     if graph is not None and self_pubkey:
@@ -395,52 +395,42 @@ async def _login_fetch_logout(
                 hop_names.append(node.name or pk[:8] if node else pk[:8])
             if hop_names:
                 via = " → ".join(hop_names)
-                console.print(
-                    f"  [blue]Route[/blue] graph path via {len(route)} hop(s): {via} "
-                    f"[dim](path={path_hex})[/dim]"
-                )
+                route_desc = f"computed path via {via}"
+                console.print(f"  [blue]Trying[/blue] {route_desc} [dim](path={path_hex})[/dim]")
             else:
-                console.print("  [blue]Route[/blue] graph path: direct")
+                route_desc = "computed direct path"
+                console.print(f"  [blue]Trying[/blue] {route_desc}")
             await mesh.commands.change_contact_path(contact, path_hex)
             logged_in = await _try_login(mesh, contact, password, attempts=3)
-            if logged_in:
-                strategy_used = "graph"
-            else:
-                console.print("  [yellow]Route[/yellow] graph path failed")
+            if not logged_in:
+                console.print(f"  [yellow]Failed[/yellow] {route_desc}")
         else:
-            console.print("  [dim]Route: no graph path available[/dim]")
+            console.print("  [dim]No computed path available[/dim]")
 
     # ── Strategy 2: Existing device route ────────────────────────────────────
     if not logged_in:
         out_path = contact.get("out_path", "")
         out_path_len = contact.get("out_path_len", 0)
         if out_path and out_path_len and out_path_len > 0:
-            console.print(
-                f"  [blue]Route[/blue] device path "
-                f"[dim](path={out_path[: out_path_len * 2]}, {out_path_len} hop(s))[/dim]"
-            )
+            route_desc = f"cached device route [dim](path={out_path[: out_path_len * 2]}, {out_path_len} hop(s))[/dim]"
         else:
-            console.print("  [blue]Route[/blue] device path [dim](direct)[/dim]")
+            route_desc = "cached device route [dim](direct)[/dim]"
+        console.print(f"  [blue]Trying[/blue] {route_desc}")
         logged_in = await _try_login(mesh, contact, password, attempts=2)
-        if logged_in:
-            strategy_used = "device"
-        else:
-            console.print("  [yellow]Route[/yellow] device path failed")
+        if not logged_in:
+            console.print("  [yellow]Failed[/yellow] cached device route")
 
     # ── Strategy 3: Flood routing ────────────────────────────────────────────
     if not logged_in:
-        console.print("  [blue]Route[/blue] flood routing")
+        route_desc = "flood routing"
+        console.print(f"  [blue]Trying[/blue] {route_desc}")
         await mesh.commands.reset_path(contact)
         logged_in = await _try_login(mesh, contact, password, attempts=2)
-        if logged_in:
-            strategy_used = "flood"
-        else:
-            console.print("  [yellow]Route[/yellow] flood failed")
+        if not logged_in:
+            console.print(f"  [yellow]Failed[/yellow] {route_desc}")
 
     if not logged_in:
         raise RuntimeError(f"Could not log in to {name!r} after all routing strategies")
-
-    console.print(f"  [green]Route[/green] connected via [bold]{strategy_used}[/bold]")
 
     # ── Fetch phase ──────────────────────────────────────────────────────────
     result = None

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -461,22 +461,18 @@ async def _login_fetch_logout(
                 console.print(f"  [yellow]Failed[/yellow] {route_desc}")
                 _set_route_vis([])
 
-    # ── Strategy 2: Original device route ────────────────────────────────────
+    # ── Strategy 2: Original device route (only if it had a real path) ──────
     if not logged_in:
-        if tried_path_hex is not None and orig_device_path_hex == tried_path_hex:
-            console.print("  [dim]Skipping original device route (same as computed path)[/dim]")
+        if not orig_device_path_hex:
+            console.print("  [dim]Skipping device route (no cached path)[/dim]")
+        elif tried_path_hex is not None and orig_device_path_hex == tried_path_hex:
+            console.print("  [dim]Skipping device route (same as computed path)[/dim]")
         else:
-            if orig_device_path_hex:
-                route_desc = (
-                    f"original device route "
-                    f"[dim](path={orig_device_path_hex}, {orig_out_path_len} hop(s))[/dim]"
-                )
-                # Restore the original device path before trying it
-                await mesh.commands.change_contact_path(contact, orig_device_path_hex)
-            else:
-                route_desc = "original device route [dim](direct)[/dim]"
-                await mesh.commands.reset_path(contact)
-            # For device route we only know source + target (no intermediate PKs)
+            route_desc = (
+                f"original device route "
+                f"[dim](path={orig_device_path_hex}, {orig_out_path_len} hop(s))[/dim]"
+            )
+            await mesh.commands.change_contact_path(contact, orig_device_path_hex)
             _set_status(f"Connecting to {name}: cached device route")
             _set_route_vis([self_pubkey, target_pk] if self_pubkey else [])
             console.print(f"  [blue]Trying[/blue] {route_desc}")

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -215,9 +215,12 @@ async def _explore(
                 graph.save(output_path)
                 continue
 
+            self_pubkey = mesh.self_info.get("public_key", "") if mesh.self_info else ""
             graph.currently_visiting = node.public_key
             try:
-                neighbours = await _login_fetch_logout(mesh, contact)
+                neighbours = await _login_fetch_logout(
+                    mesh, contact, graph=graph, self_pubkey=self_pubkey,
+                )
                 node.last_visited = datetime.now(UTC).isoformat()
                 node.visit_failed = False
 
@@ -315,29 +318,21 @@ def _find_contact_by_pubkey(pubkey: str, contacts: dict[str, Any]) -> dict[str, 
     return None
 
 
-async def _login_fetch_logout(
+async def _try_login(
     mesh: Any,
     contact: dict[str, Any],
-    password: str = "",
-) -> list[dict[str, Any]]:
-    """Login to a contact, fetch its neighbours, then logout.
+    password: str,
+    attempts: int,
+) -> bool:
+    """Attempt to log in to a contact. Returns True on success, False on timeout.
 
-    Mirrors the logic in meshmap.neighbours.get_neighbours but reuses an
-    existing mesh connection instead of creating a new one.
-
-    Raises:
-        RuntimeError: if login fails or no neighbour response is received.
+    Raises RuntimeError if the login is explicitly rejected.
     """
     name = contact.get("adv_name", "?")
-    _login_attempts = 3
-    _fetch_attempts = 3
-
-    # ── Login phase ──────────────────────────────────────────────────────────
-    logged_in = False
-    for attempt in range(1, _login_attempts + 1):
+    for attempt in range(1, attempts + 1):
         login_event = await mesh.commands.send_login(contact, password)
         if login_event and login_event.type == EventType.ERROR:
-            if attempt < _login_attempts:
+            if attempt < attempts:
                 await asyncio.sleep(2)
             continue
 
@@ -352,13 +347,61 @@ async def _login_fetch_logout(
         if t_fail in done and t_fail.result() is not None:
             raise RuntimeError(f"Login rejected by {name!r}")
         if t_ok in done and t_ok.result() is not None:
-            logged_in = True
-            break
-        if attempt < _login_attempts:
+            return True
+        if attempt < attempts:
             await asyncio.sleep(2)
 
+    return False
+
+
+async def _login_fetch_logout(
+    mesh: Any,
+    contact: dict[str, Any],
+    password: str = "",
+    graph: MeshGraph | None = None,
+    self_pubkey: str = "",
+) -> list[dict[str, Any]]:
+    """Login to a contact, fetch its neighbours, then logout.
+
+    Uses a retry cascade with progressively broader routing strategies:
+      1. Existing device route (up to 3 login attempts)
+      2. Graph-computed route via change_contact_path (up to 2 attempts)
+      3. Flood routing via reset_path (up to 2 attempts)
+
+    Raises:
+        RuntimeError: if login fails or no neighbour response is received.
+    """
+    from rich.console import Console
+
+    console = Console()
+    name = contact.get("adv_name", "?")
+    target_pk = contact.get("public_key", "")
+    _fetch_attempts = 3
+
+    # ── Strategy 1: Existing device route ────────────────────────────────────
+    console.print("  [dim]Trying existing route…[/dim]")
+    logged_in = await _try_login(mesh, contact, password, attempts=3)
+
+    # ── Strategy 2: Graph-computed route ─────────────────────────────────────
+    if not logged_in and graph is not None and self_pubkey:
+        route = graph.find_route(self_pubkey, target_pk)
+        if route is not None:
+            path_hex = graph.route_to_path_hex(route)
+            console.print(
+                f"  [dim]Trying graph route via {len(route)} hop(s) "
+                f"(path={path_hex or 'direct'})…[/dim]"
+            )
+            await mesh.commands.change_contact_path(contact, path_hex)
+            logged_in = await _try_login(mesh, contact, password, attempts=2)
+
+    # ── Strategy 3: Flood routing ────────────────────────────────────────────
     if not logged_in:
-        raise RuntimeError(f"Could not log in to {name!r} after {_login_attempts} attempt(s)")
+        console.print("  [dim]Trying flood…[/dim]")
+        await mesh.commands.reset_path(contact)
+        logged_in = await _try_login(mesh, contact, password, attempts=2)
+
+    if not logged_in:
+        raise RuntimeError(f"Could not log in to {name!r} after all routing strategies")
 
     # ── Fetch phase ──────────────────────────────────────────────────────────
     result = None

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -416,11 +416,21 @@ async def _login_fetch_logout(
         if graph is not None:
             graph.currently_trying_route = node_ids
 
-    # ── Strategy 1: Graph-computed route ─────────────────────────────────────
+    # ── Strategy 1: Graph-computed route (bidir first, then any) ────────────
     if graph is not None and self_pubkey:
-        route = graph.find_route(self_pubkey, target_pk)
-        if route is not None:
+        tried_paths: list[str] = []
+        for bidir_pass, label in [(True, "bidirectional"), (False, "any-direction")]:
+            if logged_in:
+                break
+            route = graph.find_route(self_pubkey, target_pk, require_bidir=bidir_pass)
+            if route is None:
+                console.print(f"  [dim]No {label} computed path available[/dim]")
+                continue
             path_hex = graph.route_to_path_hex(route)
+            if path_hex in tried_paths:
+                console.print(f"  [dim]Skipping {label} path (same as already tried)[/dim]")
+                continue
+            tried_paths.append(path_hex)
             tried_path_hex = path_hex
             hop_names = []
             for pk in route:
@@ -428,10 +438,10 @@ async def _login_fetch_logout(
                 hop_names.append(node.name or pk[:8] if node else pk[:8])
             if hop_names:
                 via = " → ".join(hop_names)
-                route_desc = f"computed path via {via}"
+                route_desc = f"{label} path via {via}"
                 console.print(f"  [blue]Trying[/blue] {route_desc} [dim](path={path_hex})[/dim]")
             else:
-                route_desc = "computed direct path"
+                route_desc = f"{label} direct path"
                 console.print(f"  [blue]Trying[/blue] {route_desc}")
             _set_route_vis([self_pubkey, *route, target_pk])
             await mesh.commands.change_contact_path(contact, path_hex)
@@ -439,8 +449,6 @@ async def _login_fetch_logout(
             if not logged_in:
                 console.print(f"  [yellow]Failed[/yellow] {route_desc}")
                 _set_route_vis([])
-        else:
-            console.print("  [dim]No computed path available[/dim]")
 
     # ── Strategy 2: Original device route ────────────────────────────────────
     if not logged_in:

--- a/meshmap/cli/explore.py
+++ b/meshmap/cli/explore.py
@@ -171,6 +171,19 @@ async def _explore(
         scanner.mesh = mesh  # reuse existing connection
         repeaters = await scanner.discover_zero_hop_repeaters(wait_time=int(wait_time))
 
+        # Add the scanner itself as a node so pathfinding can route from it
+        self_info = mesh.self_info or {}
+        self_pubkey = self_info.get("public_key", "")
+        if self_pubkey:
+            graph.upsert_node(
+                self_pubkey,
+                self_info.get("adv_name", "self"),
+                "node",
+                self_info.get("adv_lat"),
+                self_info.get("adv_lon"),
+                depth=0,
+            )
+
         for r in repeaters:
             canonical_pk = _resolve_pubkey(r["public_key"], mesh.contacts)
             graph.upsert_node(
@@ -181,6 +194,11 @@ async def _explore(
                 r.get("lon"),
                 depth=0,
             )
+            # Create edge from scanner to 0-hop repeater so pathfinding works
+            snr = r.get("snr")
+            if self_pubkey and snr is not None:
+                graph.upsert_edge(listener=self_pubkey, talker=canonical_pk, snr=snr)
+
         console.print(f"[dim]Found {len(repeaters)} 0-hop repeater(s).[/dim]")
         graph.save(output_path)
 

--- a/meshmap/graph.py
+++ b/meshmap/graph.py
@@ -214,7 +214,9 @@ class MeshGraph:
     # Routing / pathfinding
     # ------------------------------------------------------------------
 
-    def find_route(self, source: str, target: str) -> list[str] | None:
+    def find_route(
+        self, source: str, target: str, *, require_bidir: bool = False
+    ) -> list[str] | None:
         """Find shortest route between two nodes using Dijkstra's algorithm.
 
         Returns a list of **intermediate** node pubkeys (excluding source and
@@ -222,7 +224,11 @@ class MeshGraph:
 
         Edge cost balances hops and SNR:  cost = 1.0 + max(0, 20 - snr) / 10
         Uses the minimum SNR of both directions (conservative).
-        Edges with no SNR data at all are skipped (treated as disconnected).
+
+        If require_bidir is True, only edges with SNR data in BOTH directions
+        are considered (more reliable for two-way communication).
+        If False, edges with at least one direction are included.
+        Edges with no SNR data at all are always skipped.
         """
         if source == target:
             return []
@@ -232,9 +238,13 @@ class MeshGraph:
         # Build adjacency list
         adj: dict[str, list[tuple[str, float]]] = {pk: [] for pk in self.nodes}
         for (a, b), edge in self._edges.items():
-            snr_vals = [v for v in (edge.snr_a_hears_b, edge.snr_b_hears_a) if v is not None]
-            if not snr_vals:
+            has_ab = edge.snr_a_hears_b is not None
+            has_ba = edge.snr_b_hears_a is not None
+            if not has_ab and not has_ba:
                 continue  # no SNR data — treat as disconnected
+            if require_bidir and not (has_ab and has_ba):
+                continue  # skip unidirectional edges
+            snr_vals = [v for v in (edge.snr_a_hears_b, edge.snr_b_hears_a) if v is not None]
             snr = min(snr_vals)
             cost = 1.0 + max(0, 20 - snr) / 10
             adj[a].append((b, cost))

--- a/meshmap/graph.py
+++ b/meshmap/graph.py
@@ -231,9 +231,7 @@ class MeshGraph:
         # Build adjacency list
         adj: dict[str, list[tuple[str, float]]] = {pk: [] for pk in self.nodes}
         for (a, b), edge in self._edges.items():
-            snr_vals = [
-                v for v in (edge.snr_a_hears_b, edge.snr_b_hears_a) if v is not None
-            ]
+            snr_vals = [v for v in (edge.snr_a_hears_b, edge.snr_b_hears_a) if v is not None]
             if not snr_vals:
                 continue  # no SNR data — treat as disconnected
             snr = min(snr_vals)

--- a/meshmap/graph.py
+++ b/meshmap/graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import heapq
 import json
 import os
 import threading
@@ -207,6 +208,77 @@ class MeshGraph:
             "pending": pending,
             "failed": failed,
         }
+
+    # ------------------------------------------------------------------
+    # Routing / pathfinding
+    # ------------------------------------------------------------------
+
+    def find_route(self, source: str, target: str) -> list[str] | None:
+        """Find shortest route between two nodes using Dijkstra's algorithm.
+
+        Returns a list of **intermediate** node pubkeys (excluding source and
+        target), or None if unreachable.
+
+        Edge cost balances hops and SNR:  cost = 1.0 + max(0, 20 - snr) / 10
+        Uses the minimum SNR of both directions (conservative).
+        Edges with no SNR data at all are skipped (treated as disconnected).
+        """
+        if source == target:
+            return []
+        if source not in self.nodes or target not in self.nodes:
+            return None
+
+        # Build adjacency list
+        adj: dict[str, list[tuple[str, float]]] = {pk: [] for pk in self.nodes}
+        for (a, b), edge in self._edges.items():
+            snr_vals = [
+                v for v in (edge.snr_a_hears_b, edge.snr_b_hears_a) if v is not None
+            ]
+            if not snr_vals:
+                continue  # no SNR data — treat as disconnected
+            snr = min(snr_vals)
+            cost = 1.0 + max(0, 20 - snr) / 10
+            adj[a].append((b, cost))
+            adj[b].append((a, cost))
+
+        # Dijkstra
+        dist: dict[str, float] = {source: 0.0}
+        prev: dict[str, str | None] = {source: None}
+        heap: list[tuple[float, str]] = [(0.0, source)]
+
+        while heap:
+            d, u = heapq.heappop(heap)
+            if u == target:
+                break
+            if d > dist.get(u, float("inf")):
+                continue
+            for v, w in adj.get(u, []):
+                nd = d + w
+                if nd < dist.get(v, float("inf")):
+                    dist[v] = nd
+                    prev[v] = u
+                    heapq.heappush(heap, (nd, v))
+
+        if target not in prev:
+            return None
+
+        # Reconstruct path and return intermediates only
+        path: list[str] = []
+        cur: str | None = target
+        while cur is not None:
+            path.append(cur)
+            cur = prev.get(cur)
+        path.reverse()
+        # path = [source, ..., target] — return intermediates
+        return path[1:-1]
+
+    def route_to_path_hex(self, route: list[str]) -> str:
+        """Encode a route (list of intermediate pubkeys) as a hex path string.
+
+        Each hop is represented by the first byte of its pubkey.
+        E.g. ["ab12...", "cd34..."] → "abcd"
+        """
+        return "".join(pk[:2] for pk in route)
 
     # ------------------------------------------------------------------
     # Serialisation for D3

--- a/meshmap/graph.py
+++ b/meshmap/graph.py
@@ -51,6 +51,7 @@ class MeshGraph:
         self._lock = threading.Lock()
         self.currently_visiting: str | None = None  # transient; not persisted
         self.currently_trying_route: list[str] = []  # transient; node IDs of active route attempt
+        self.status_message: str = ""  # transient; human-readable action for the web UI
 
     # ------------------------------------------------------------------
     # Persistence
@@ -325,4 +326,5 @@ class MeshGraph:
             "links": links,
             "currently_visiting": self.currently_visiting,
             "currently_trying_route": self.currently_trying_route,
+            "status_message": self.status_message,
         }

--- a/meshmap/graph.py
+++ b/meshmap/graph.py
@@ -50,6 +50,7 @@ class MeshGraph:
         self._edges: dict[tuple[str, str], GraphEdge] = {}
         self._lock = threading.Lock()
         self.currently_visiting: str | None = None  # transient; not persisted
+        self.currently_trying_route: list[str] = []  # transient; node IDs of active route attempt
 
     # ------------------------------------------------------------------
     # Persistence
@@ -309,4 +310,9 @@ class MeshGraph:
                 }
                 for e in self._edges.values()
             ]
-        return {"nodes": nodes, "links": links, "currently_visiting": self.currently_visiting}
+        return {
+            "nodes": nodes,
+            "links": links,
+            "currently_visiting": self.currently_visiting,
+            "currently_trying_route": self.currently_trying_route,
+        }

--- a/meshmap/web/static/index.html
+++ b/meshmap/web/static/index.html
@@ -256,6 +256,7 @@
     <div class="stat">Visited: <span id="s-visited">0</span></div>
     <div class="stat">Pending: <span id="s-pending">0</span></div>
     <div class="stat">Failed: <span id="s-failed">0</span></div>
+    <div id="s-status" style="margin-top:6px;color:#58a6ff;font-size:11px;min-height:1.4em"></div>
   </div>
 
   <div id="legend">
@@ -746,6 +747,7 @@
       document.getElementById('s-visited').textContent = s.visited ?? '—';
       document.getElementById('s-pending').textContent = s.pending ?? '—';
       document.getElementById('s-failed').textContent = s.failed ?? '—';
+      document.getElementById('s-status').textContent = data.status_message || '';
 
       // Update depth slider bounds if new deeper nodes arrived
       const newMaxDepth = Math.max(0, ...data.nodes.map(n => n.depth || 0));

--- a/meshmap/web/static/index.html
+++ b/meshmap/web/static/index.html
@@ -72,7 +72,7 @@
       stroke: #58a6ff;
       stroke-width: 3px;
     }
-    .link-group.on-route .link-path {
+    .link-group.on-route .link-path.on-route-dir {
       stroke: #58a6ff !important;
       stroke-width: 3px !important;
       stroke-opacity: 1 !important;
@@ -502,21 +502,28 @@
   function updateAttributes() {
     if (!nodeSel || !linkGroupSel) return;
     const routeSet = new Set(currentlyTryingRoute);
-    // Build set of consecutive route edge pairs for link highlighting
-    const routeEdges = new Set();
+    // Build a map of route edges: canonical key → direction the route travels
+    // Direction is 'ab' if route goes from link.source → link.target, 'ba' if reverse
+    const routeEdgeDir = new Map();
     for (let i = 0; i < currentlyTryingRoute.length - 1; i++) {
-      const a = currentlyTryingRoute[i], b = currentlyTryingRoute[i + 1];
-      routeEdges.add(a < b ? `${a}~${b}` : `${b}~${a}`);
+      const from = currentlyTryingRoute[i], to = currentlyTryingRoute[i + 1];
+      const key = from < to ? `${from}~${to}` : `${to}~${from}`;
+      // 'ab' means route goes source→target (a→b), 'ba' means target→source (b→a)
+      routeEdgeDir.set(key, from < to ? 'ab' : 'ba');
     }
     nodeSel
       .classed('visiting', d => d.id === currentlyVisitingId)
       .classed('on-route', d => routeSet.has(d.id));
-    linkGroupSel
-      .classed('on-route', d => {
-        const s = d.source.id || d.source;
-        const t = d.target.id || d.target;
-        return routeEdges.has(s < t ? `${s}~${t}` : `${t}~${s}`);
-      });
+    linkGroupSel.each(function(d) {
+      const s = d.source.id || d.source;
+      const t = d.target.id || d.target;
+      const key = s < t ? `${s}~${t}` : `${t}~${s}`;
+      const dir = routeEdgeDir.get(key);
+      const g = d3.select(this);
+      g.classed('on-route', !!dir);
+      g.select('.link-ab').classed('on-route-dir', dir === 'ab');
+      g.select('.link-ba').classed('on-route-dir', dir === 'ba');
+    });
     nodeSel.select('circle')
       .attr('r', nodeRadius)
       .attr('fill', nodeColor)
@@ -604,16 +611,16 @@
     if (currentlyTryingRoute.length > 1) {
       // Route attempt: highlight route nodes + edges, dim everything else
       const routeSet = new Set(currentlyTryingRoute);
-      const routeEdges = new Set();
+      const routeKeys = new Set();
       for (let i = 0; i < currentlyTryingRoute.length - 1; i++) {
         const a = currentlyTryingRoute[i], b = currentlyTryingRoute[i + 1];
-        routeEdges.add(a < b ? `${a}~${b}` : `${b}~${a}`);
+        routeKeys.add(a < b ? `${a}~${b}` : `${b}~${a}`);
       }
       nodeSel.attr('opacity', d => routeSet.has(d.id) ? null : 0.15);
       linkGroupSel.attr('opacity', d => {
         const s = d.source.id || d.source, t = d.target.id || d.target;
         const key = s < t ? `${s}~${t}` : `${t}~${s}`;
-        return routeEdges.has(key) ? null : 0.06;
+        return routeKeys.has(key) ? null : 0.06;
       });
     } else if (hoveredNodeId != null) {
       // Hover: highlight node + direct neighbours, dim everything else

--- a/meshmap/web/static/index.html
+++ b/meshmap/web/static/index.html
@@ -64,6 +64,22 @@
       animation: visiting-blink 0.9s ease-in-out infinite;
     }
 
+    /* Route being attempted — animated dashed highlight */
+    @keyframes route-dash {
+      to { stroke-dashoffset: -20; }
+    }
+    .node.on-route circle {
+      stroke: #58a6ff;
+      stroke-width: 3px;
+    }
+    .link-group.on-route .link-path {
+      stroke: #58a6ff !important;
+      stroke-width: 3px !important;
+      stroke-opacity: 1 !important;
+      stroke-dasharray: 6 4;
+      animation: route-dash 0.6s linear infinite;
+    }
+
     /* Status bar */
     #status {
       position: fixed;
@@ -312,6 +328,7 @@
 
   let hoveredNodeId = null;
   let currentlyVisitingId = null;
+  let currentlyTryingRoute = [];  // ordered node IDs of the route being attempted
 
   // Filter / spread state
   let filterMinDepth = 0;
@@ -460,8 +477,22 @@
   // ── DOM-only attribute update (no layout recomputation) ───────────────────
   function updateAttributes() {
     if (!nodeSel || !linkGroupSel) return;
+    const routeSet = new Set(currentlyTryingRoute);
+    // Build set of consecutive route edge pairs for link highlighting
+    const routeEdges = new Set();
+    for (let i = 0; i < currentlyTryingRoute.length - 1; i++) {
+      const a = currentlyTryingRoute[i], b = currentlyTryingRoute[i + 1];
+      routeEdges.add(a < b ? `${a}~${b}` : `${b}~${a}`);
+    }
     nodeSel
-      .classed('visiting', d => d.id === currentlyVisitingId);
+      .classed('visiting', d => d.id === currentlyVisitingId)
+      .classed('on-route', d => routeSet.has(d.id));
+    linkGroupSel
+      .classed('on-route', d => {
+        const s = d.source.id || d.source;
+        const t = d.target.id || d.target;
+        return routeEdges.has(s < t ? `${s}~${t}` : `${t}~${s}`);
+      });
     nodeSel.select('circle')
       .attr('r', nodeRadius)
       .attr('fill', nodeColor)
@@ -546,7 +577,21 @@
   function applyOpacity() {
     if (!nodeSel || !linkGroupSel) return;
 
-    if (hoveredNodeId != null) {
+    if (currentlyTryingRoute.length > 1) {
+      // Route attempt: highlight route nodes + edges, dim everything else
+      const routeSet = new Set(currentlyTryingRoute);
+      const routeEdges = new Set();
+      for (let i = 0; i < currentlyTryingRoute.length - 1; i++) {
+        const a = currentlyTryingRoute[i], b = currentlyTryingRoute[i + 1];
+        routeEdges.add(a < b ? `${a}~${b}` : `${b}~${a}`);
+      }
+      nodeSel.attr('opacity', d => routeSet.has(d.id) ? null : 0.15);
+      linkGroupSel.attr('opacity', d => {
+        const s = d.source.id || d.source, t = d.target.id || d.target;
+        const key = s < t ? `${s}~${t}` : `${t}~${s}`;
+        return routeEdges.has(key) ? null : 0.06;
+      });
+    } else if (hoveredNodeId != null) {
       // Hover: highlight node + direct neighbours, dim everything else
       const connectedIds = new Set([hoveredNodeId]);
       linkGroupSel.each(d => {
@@ -692,6 +737,7 @@
       const data = await res.json();
 
       currentlyVisitingId = data.currently_visiting || null;
+      currentlyTryingRoute = data.currently_trying_route || [];
 
       // Always update status bar counters
       const s = data.stats || {};

--- a/meshmap/web/static/index.html
+++ b/meshmap/web/static/index.html
@@ -236,6 +236,26 @@
       cursor: pointer;
     }
     .sl-sep { color: #6e7681; }
+
+    /* Activity status */
+    #activity {
+      position: fixed;
+      bottom: 12px;
+      right: 12px;
+      background: rgba(13, 17, 23, 0.88);
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 8px 14px;
+      font-size: 12px;
+      color: #58a6ff;
+      backdrop-filter: blur(4px);
+      max-width: 400px;
+      transition: opacity 0.3s ease;
+    }
+    #activity:empty, #activity:has(#s-status:empty) {
+      opacity: 0;
+      pointer-events: none;
+    }
   </style>
 </head>
 <body>
@@ -256,7 +276,6 @@
     <div class="stat">Visited: <span id="s-visited">0</span></div>
     <div class="stat">Pending: <span id="s-pending">0</span></div>
     <div class="stat">Failed: <span id="s-failed">0</span></div>
-    <div id="s-status" style="margin-top:6px;color:#58a6ff;font-size:11px;min-height:1.4em"></div>
   </div>
 
   <div id="legend">
@@ -315,6 +334,10 @@
   </div>
 
   <div id="tooltip"></div>
+
+  <div id="activity">
+    <span id="s-status"></span>
+  </div>
 
   <script>
   'use strict';

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,217 @@
+"""Tests for meshmap.graph — MeshGraph pathfinding and routing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from meshmap.graph import GraphEdge, MeshGraph
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_graph(*edges: tuple[str, str, float, float | None]) -> MeshGraph:
+    """Build a graph from (a, b, snr_a_hears_b, snr_b_hears_a) tuples.
+
+    Nodes are auto-created as "repeater" type.
+    """
+    g = MeshGraph()
+    nodes_seen: set[str] = set()
+    for a, b, snr_ab, snr_ba in edges:
+        for pk in (a, b):
+            if pk not in nodes_seen:
+                g.upsert_node(pk, pk[:4], "repeater", None, None)
+                nodes_seen.add(pk)
+        g.upsert_edge(listener=a, talker=b, snr=snr_ab)
+        if snr_ba is not None:
+            g.upsert_edge(listener=b, talker=a, snr=snr_ba)
+    return g
+
+
+# ---------------------------------------------------------------------------
+# find_route
+# ---------------------------------------------------------------------------
+
+
+class TestFindRoute:
+    def test_same_node(self):
+        g = MeshGraph()
+        g.upsert_node("aaa", "A", "repeater", None, None)
+        assert g.find_route("aaa", "aaa") == []
+
+    def test_unknown_node_returns_none(self):
+        g = MeshGraph()
+        g.upsert_node("aaa", "A", "repeater", None, None)
+        assert g.find_route("aaa", "zzz") is None
+
+    def test_direct_neighbours(self):
+        g = _make_graph(("aaa", "bbb", 15.0, 14.0))
+        route = g.find_route("aaa", "bbb")
+        assert route == []  # direct — no intermediates
+
+    def test_two_hop_route(self):
+        g = _make_graph(
+            ("aaa", "bbb", 15.0, 14.0),
+            ("bbb", "ccc", 12.0, 10.0),
+        )
+        route = g.find_route("aaa", "ccc")
+        assert route == ["bbb"]
+
+    def test_prefers_good_snr_over_fewer_hops(self):
+        """Direct A→C has terrible SNR; A→B→C via good SNR should win."""
+        g = _make_graph(
+            ("aaa", "bbb", 15.0, 14.0),  # good link
+            ("bbb", "ccc", 12.0, 10.0),  # decent link
+            ("aaa", "ccc", -5.0, -8.0),  # terrible direct link
+        )
+        route = g.find_route("aaa", "ccc")
+        assert route == ["bbb"]
+
+    def test_prefers_fewer_hops_with_equal_snr(self):
+        """When SNR is similar, prefer the shorter path."""
+        g = _make_graph(
+            ("aaa", "bbb", 18.0, 18.0),
+            ("bbb", "ccc", 18.0, 18.0),
+            ("aaa", "ccc", 18.0, 18.0),  # direct with same good SNR
+        )
+        route = g.find_route("aaa", "ccc")
+        assert route == []  # direct is preferred
+
+    def test_disconnected_nodes(self):
+        """Nodes with no edges between clusters are unreachable."""
+        g = _make_graph(
+            ("aaa", "bbb", 10.0, 10.0),
+        )
+        g.upsert_node("ccc", "C", "repeater", None, None)
+        assert g.find_route("aaa", "ccc") is None
+
+    def test_no_snr_edge_treated_as_disconnected(self):
+        """Edges with no SNR data at all should be skipped."""
+        g = MeshGraph()
+        g.upsert_node("aaa", "A", "repeater", None, None)
+        g.upsert_node("bbb", "B", "repeater", None, None)
+        # Manually create an edge with no SNR
+        g._edges[("aaa", "bbb")] = GraphEdge(
+            node_a="aaa",
+            node_b="bbb",
+            last_seen="2024-01-01",
+            snr_a_hears_b=None,
+            snr_b_hears_a=None,
+        )
+        assert g.find_route("aaa", "bbb") is None
+
+    def test_one_direction_snr_uses_that_value(self):
+        """If only one direction has SNR, use it (don't skip the edge)."""
+        g = MeshGraph()
+        g.upsert_node("aaa", "A", "repeater", None, None)
+        g.upsert_node("bbb", "B", "repeater", None, None)
+        g.upsert_edge(listener="aaa", talker="bbb", snr=10.0)
+        # Only one direction set
+        route = g.find_route("aaa", "bbb")
+        assert route == []
+
+    def test_uses_min_snr_of_both_directions(self):
+        """Cost should use the worse (min) of two SNR directions."""
+        # Route 1: A→B with asymmetric SNR (good one way, bad the other)
+        # Route 2: A→C→B with consistently decent SNR
+        g = _make_graph(
+            ("aaa", "bbb", 20.0, -5.0),  # min = -5, cost = 3.5
+            ("aaa", "ccc", 10.0, 10.0),  # min = 10, cost = 2.0
+            ("ccc", "bbb", 10.0, 10.0),  # min = 10, cost = 2.0
+        )
+        g.find_route("aaa", "bbb")
+        # Via ccc: 2.0 + 2.0 = 4.0, Direct: 3.5 — direct is still cheaper
+        # Let's make the asymmetry worse
+        g2 = _make_graph(
+            ("aaa", "bbb", 20.0, -10.0),  # min = -10, cost = 4.0
+            ("aaa", "ccc", 12.0, 12.0),  # min = 12, cost = 1.8
+            ("ccc", "bbb", 12.0, 12.0),  # min = 12, cost = 1.8
+        )
+        route2 = g2.find_route("aaa", "bbb")
+        assert route2 == ["ccc"]  # 1.8 + 1.8 = 3.6 < 4.0
+
+    def test_multi_hop_route(self):
+        g = _make_graph(
+            ("aaa", "bbb", 15.0, 15.0),
+            ("bbb", "ccc", 15.0, 15.0),
+            ("ccc", "ddd", 15.0, 15.0),
+            ("ddd", "eee", 15.0, 15.0),
+        )
+        route = g.find_route("aaa", "eee")
+        assert route == ["bbb", "ccc", "ddd"]
+
+
+# ---------------------------------------------------------------------------
+# route_to_path_hex
+# ---------------------------------------------------------------------------
+
+
+class TestRouteToPathHex:
+    def test_empty_route(self):
+        g = MeshGraph()
+        assert g.route_to_path_hex([]) == ""
+
+    def test_single_hop(self):
+        g = MeshGraph()
+        assert g.route_to_path_hex(["ab1234"]) == "ab"
+
+    def test_multiple_hops(self):
+        g = MeshGraph()
+        assert g.route_to_path_hex(["ab1234", "cd5678", "ef9012"]) == "abcdef"
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_save_load_preserves_graph(self, tmp_path: Path):
+        g = _make_graph(
+            ("aaa", "bbb", 15.0, 14.0),
+            ("bbb", "ccc", 10.0, 12.0),
+        )
+        out = tmp_path / "graph.json"
+        g.save(out)
+
+        g2 = MeshGraph.load(out)
+        assert set(g2.nodes.keys()) == {"aaa", "bbb", "ccc"}
+        assert len(g2._edges) == 2
+        # Pathfinding should work on loaded graph
+        assert g2.find_route("aaa", "ccc") == ["bbb"]
+
+    def test_load_nonexistent_returns_empty(self, tmp_path: Path):
+        g = MeshGraph.load(tmp_path / "missing.json")
+        assert len(g.nodes) == 0
+        assert len(g._edges) == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cost sanity checks
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCostFormula:
+    """Verify the cost formula produces expected values at key SNR points."""
+
+    def test_cost_at_good_snr(self):
+        # SNR = 15 → cost = 1.0 + max(0, 20-15)/10 = 1.5
+        g = _make_graph(("aaa", "bbb", 15.0, 15.0))
+        # Direct route should exist
+        assert g.find_route("aaa", "bbb") == []
+
+    def test_cost_at_zero_snr(self):
+        # SNR = 0 → cost = 1.0 + max(0, 20-0)/10 = 3.0
+        g = _make_graph(("aaa", "bbb", 0.0, 0.0))
+        assert g.find_route("aaa", "bbb") == []
+
+    def test_cost_at_negative_snr(self):
+        # SNR = -10 → cost = 1.0 + max(0, 20-(-10))/10 = 4.0
+        g = _make_graph(("aaa", "bbb", -10.0, -10.0))
+        assert g.find_route("aaa", "bbb") == []
+
+    def test_high_snr_cost_floors_at_one(self):
+        # SNR = 25 → cost = 1.0 + max(0, 20-25)/10 = 1.0
+        g = _make_graph(("aaa", "bbb", 25.0, 25.0))
+        assert g.find_route("aaa", "bbb") == []

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -143,6 +143,58 @@ class TestFindRoute:
 
 
 # ---------------------------------------------------------------------------
+# find_route with require_bidir
+# ---------------------------------------------------------------------------
+
+
+class TestFindRouteBidir:
+    def test_bidir_skips_unidirectional_edges(self):
+        """Bidirectional mode should not use edges with only one SNR direction."""
+        g = MeshGraph()
+        g.upsert_node("aaa", "A", "repeater", None, None)
+        g.upsert_node("bbb", "B", "repeater", None, None)
+        g.upsert_edge(listener="aaa", talker="bbb", snr=10.0)
+        # Only one direction — bidir should fail
+        assert g.find_route("aaa", "bbb", require_bidir=True) is None
+        # Non-bidir should succeed
+        assert g.find_route("aaa", "bbb", require_bidir=False) == []
+
+    def test_bidir_uses_bidirectional_edges(self):
+        """Bidirectional mode should use edges with both SNR directions."""
+        g = _make_graph(
+            ("aaa", "bbb", 15.0, 14.0),
+            ("bbb", "ccc", 12.0, 10.0),
+        )
+        assert g.find_route("aaa", "ccc", require_bidir=True) == ["bbb"]
+
+    def test_bidir_routes_around_unidir_link(self):
+        """When a direct link is unidirectional, bidir should route around it."""
+        g = _make_graph(
+            ("aaa", "bbb", 15.0, 14.0),  # bidir
+            ("bbb", "ccc", 12.0, 10.0),  # bidir
+        )
+        # Add a direct A→C link but unidirectional
+        g.upsert_edge(listener="aaa", talker="ccc", snr=20.0)
+        # bidir: must go via bbb
+        assert g.find_route("aaa", "ccc", require_bidir=True) == ["bbb"]
+        # any-direction: direct is cheaper
+        assert g.find_route("aaa", "ccc", require_bidir=False) == []
+
+    def test_bidir_unreachable_but_unidir_reachable(self):
+        """No bidir path exists, but a unidir one does."""
+        g = MeshGraph()
+        g.upsert_node("aaa", "A", "repeater", None, None)
+        g.upsert_node("bbb", "B", "repeater", None, None)
+        g.upsert_node("ccc", "C", "repeater", None, None)
+        # A-B: only A heard B
+        g.upsert_edge(listener="aaa", talker="bbb", snr=10.0)
+        # B-C: only B heard C
+        g.upsert_edge(listener="bbb", talker="ccc", snr=10.0)
+        assert g.find_route("aaa", "ccc", require_bidir=True) is None
+        assert g.find_route("aaa", "ccc", require_bidir=False) == ["bbb"]
+
+
+# ---------------------------------------------------------------------------
 # route_to_path_hex
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds Dijkstra pathfinding (`find_route()`) to `MeshGraph` with SNR-weighted edge costs that balance hop count and signal quality
- Implements a multi-strategy routing retry cascade in `_login_fetch_logout`:
  1. **Bidirectional computed route** (3 attempts) — Dijkstra using only edges with SNR in both directions
  2. **Any-direction computed route** (3 attempts) — Dijkstra including unidirectional edges (skipped if same path)
  3. **Original device route** (2 attempts) — the device's cached path, snapshotted before modification
  4. **Flood routing** (2 attempts) — `reset_path` broadcast fallback
- Duplicate paths are detected and skipped at each stage
- Adds the scanner node to the graph with edges to 0-hop repeaters, so pathfinding has a starting point
- Snapshots the device's cached route before overwriting it with computed paths
- Detailed Rich console logging for each strategy attempt with node names and path hex
- **Web UI route visualization**: active route highlighted with animated dashed blue lines and dimmed non-route elements
- 24 new tests for pathfinding (including bidir/unidir), path encoding, persistence, and edge cost formula

## Changes
- `meshmap/graph.py` — `find_route(require_bidir=)`, `route_to_path_hex()`, `currently_trying_route` field
- `meshmap/cli/explore.py` — routing retry cascade, scanner node insertion, route visualization hooks
- `meshmap/web/static/index.html` — CSS animation + JS for route highlighting
- `tests/test_graph.py` — new test file (24 tests)

## Test plan
- [x] All 94 tests pass (24 new + 70 existing)
- [x] CI passes (formatting, Python 3.12, 3.13, macOS)
- [ ] Run `meshmap explore --resume --refresh --serve` and verify:
  - Bidirectional route tried first, then any-direction if different
  - Original device route is correctly snapshotted and tried when different
  - Web UI highlights the active route with animated dashed blue edges
  - Route visualization clears between strategies and after completion

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)